### PR TITLE
added version check to EPMC client, provides a warning

### DIFF
--- a/octopus/modules/epmc/client.py
+++ b/octopus/modules/epmc/client.py
@@ -27,7 +27,7 @@ def check_epmc_version(resp_json):
         if received_ver != configured_ver:
             app.logger.warn("Mismatching EPMC API version; recommend checking for changes. Expected '{0}' Found '{1}'".format(configured_ver, received_ver))
     except KeyError:
-        # The json doesn't have a version key, that's not the end of the world.
+        app.logger.warn("Couldn't check EPMC API version; did not find 'version' key in response. Proceed with caution as the EPMC API may have changed.")
         pass
 
 

--- a/octopus/modules/epmc/client.py
+++ b/octopus/modules/epmc/client.py
@@ -20,6 +20,17 @@ def quote(s, **kwargs):
         return None
 
 
+def check_epmc_version(resp_json):
+    try:
+        received_ver = resp_json['version']
+        configured_ver = app.config.get("EPMC_TARGET_VERSION")
+        if received_ver != configured_ver:
+            app.logger.warn("Mismatching EPMC API version; recommend checking for changes. Expected '{0}' Found '{1}'".format(configured_ver, received_ver))
+    except KeyError:
+        # The json doesn't have a version key, that's not the end of the world.
+        pass
+
+
 def to_keywords(s):
     # FIXME: this method does not strip stop words - investigations into that indicate that as a natural language
     # processing thing, the libraries required to do it (e.g. NLTK) are awkward and overblown for our purposes.
@@ -140,6 +151,7 @@ class EuropePMC(object):
 
         try:
             j = resp.json()
+            check_epmc_version(j)
         except:
             raise EuropePMCException(message="could not decode JSON from EPMC response")
 

--- a/octopus/modules/epmc/settings.py
+++ b/octopus/modules/epmc/settings.py
@@ -1,2 +1,3 @@
 
 EPMC_REST_API = "http://www.ebi.ac.uk/europepmc/webservices/rest/"
+EPMC_TARGET_VERSION = "5.2.1"


### PR DESCRIPTION
It's a soft check, really, as updates may not break the implementation.

Warning looks like this in logs:
```
--------------------------------------------------------------------------------
2017-09-05 17:49:04,837
WARNING in client [/Users/steve/code/cl/harvester/src/magnificent-octopus/octopus/modules/epmc/client.py:28]:
Mismatching EPMC API version; recommend checking for changes. Expected '5.1.1' Found '5.2.1'
--------------------------------------------------------------------------------
```