### PR TITLE
catch other DOI link forms as well

### DIFF
--- a/octopus/modules/identifiers/doi.py
+++ b/octopus/modules/identifiers/doi.py
@@ -4,7 +4,7 @@ def normalise(doi):
 
     doi = doi.strip()
 
-    rx = "^((http:\/\/){0,1}dx.doi.org/|(http:\/\/){0,1}hdl.handle.net\/|doi:|info:doi:){0,1}(?P<id>10\\..+\/.+)"
+    rx = "^((http(s){0,1}:\/\/){0,1}(dx.){0,1}doi.org/|(http:\/\/){0,1}hdl.handle.net\/|doi:|info:doi:){0,1}(?P<id>10\\..+\/.+)"
     result = re.match(rx, doi)
     if result is None:
         raise ValueError(doi + " does not seem to be a valid DOI")

--- a/octopus/modules/identifiers/doi.py
+++ b/octopus/modules/identifiers/doi.py
@@ -4,7 +4,7 @@ def normalise(doi):
 
     doi = doi.strip()
 
-    rx = "^((http(s){0,1}:\/\/){0,1}(dx.){0,1}doi.org/|(http:\/\/){0,1}hdl.handle.net\/|doi:|info:doi:){0,1}(?P<id>10\\..+\/.+)"
+    rx = "^((https?:\/\/)?(dx\.)?doi.org/|(https?:\/\/)?hdl\.handle\.net\/|doi:|info:doi:)?(?P<id>10\\..+\/.+)"
     result = re.match(rx, doi)
     if result is None:
         raise ValueError(doi + " does not seem to be a valid DOI")


### PR DESCRIPTION
Hello!

Because the [new DOI resolver recommendation](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) is to use `https` but not `dx` I thought it might be helpful to expand the reg-ex to all 4 possible combinations. I [tested the change in regexr.com](https://regexr.com/3k9nm).

Also, there [seems to be the shortcut `?` for `{0,1}`](https://docs.perl6.org/language/regexes.html#Zero_or_one:_?). Shall I change that as well?

